### PR TITLE
Bug fix: V3鉴权时的Host设值问题

### DIFF
--- a/TencentCloud/Common/Http/HttpConnection.cs
+++ b/TencentCloud/Common/Http/HttpConnection.cs
@@ -69,6 +69,14 @@ namespace TencentCloud.Common.Http
             // 计算签名时将charset添加到了Content-Type中
             request.ContentType = headers[contentTypeName] + "; charset=utf-8";
             headers.Remove(contentTypeName);
+            // Bug fix:
+            // 通过Host属性设置Host值。如果通过Header集合添加Host值，则会引发异常，错误消息为：
+            // “The 'Host' header must be modified using the appropriate property or method”。
+            if (headers.ContainsKey("Host"))
+            {
+                request.Host = headers["Host"];
+                headers.Remove("Host");
+            }
             foreach (KeyValuePair<string, string> kvp in headers)
             {
                 request.Headers.Add(kvp.Key, kvp.Value);


### PR DESCRIPTION
使用V3鉴权时（SignMethod = "TC3-HMAC-SHA256"），HttpConnection.CreateHttp方法会通过HttpWebRequest.Headers添加Host值，这会引发以下异常：

> TencentCloud.Common.TencentCloudSDKException: The request with exception: The 'Host' header must be modified using the appropriate property or method.
> Parameter name: name 
>    at TencentCloud.Common.AbstractClient.RequestV3Sync(AbstractModel request,
> String actionName)
>    at TencentCloud.Common.AbstractClient.InternalRequestSync(AbstractModel request,
> String actionName)
>    at TencentCloud.Ocr.V20181119.OcrClient.BankCardOCRSync(BankCardOCRRequest req)

改为通过HttpWebRequest.Host属性设置Host值可以修复问题。